### PR TITLE
feat: implementa cadastro de clínica e usuário (app + backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/pet_flow_backend/swagger_output.json
 .vscode/
 .kiro/
 .expo/
+*.zip

--- a/src/pet_flow_backend/services/auth/auth.controller.ts
+++ b/src/pet_flow_backend/services/auth/auth.controller.ts
@@ -37,13 +37,42 @@ export class AuthController {
 
   async register(req: Request, res: Response): Promise<void> {
     try {
-      const { email, password } = req.body;
+      const {
+        email,
+        password,
+        clinicName,
+        cnpj,
+        address,
+        phone,
+        ownerName,
+        cpf,
+      } = req.body;
+
       if (!email || !password) {
         res.status(400).json({ error: "Email and password are required" });
         return;
       }
 
-      const { data, error } = await this.service.register(email, password);
+      if (!clinicName) {
+        res.status(400).json({ error: "Clinic name is required" });
+        return;
+      }
+
+      if (!ownerName) {
+        res.status(400).json({ error: "Owner name is required" });
+        return;
+      }
+
+      const { data, error } = await this.service.register({
+        email,
+        password,
+        clinicName,
+        cnpj,
+        address,
+        phone,
+        ownerName,
+        cpf,
+      });
 
       if (error) {
         res.status(400).json({ error: error.message });
@@ -58,7 +87,9 @@ export class AuthController {
       res.status(201).json(this.mapper.toObject(data));
     } catch (err: unknown) {
       Logger.error("[AuthController] register error:", err);
-      res.status(500).json({ error: "Internal Server Error" });
+      const message =
+        err instanceof Error ? err.message : "Internal Server Error";
+      res.status(400).json({ error: message });
     }
   }
 

--- a/src/pet_flow_backend/services/auth/auth.service.ts
+++ b/src/pet_flow_backend/services/auth/auth.service.ts
@@ -1,16 +1,88 @@
 import { AuthRepository } from "./repositories/auth.repository";
 import { Auth } from "./domain/models/auth";
 import { DbResult } from "../../shared/utils/supabase.extensions";
+import { ClinicService } from "../clinic/clinic.service";
+import { EmployeeService } from "../employee/employee.service";
+
+export interface RegisterInput {
+  email: string;
+  password: string;
+  clinicName: string;
+  cnpj?: string;
+  address?: string;
+  phone?: string;
+  ownerName: string;
+  cpf?: string;
+}
 
 export class AuthService {
-  constructor(private readonly repository: AuthRepository) {}
+  constructor(
+    private readonly repository: AuthRepository,
+    private readonly clinicService: ClinicService,
+    private readonly employeeService: EmployeeService,
+  ) {}
 
   async login(email: string, password: string): Promise<DbResult<Auth>> {
     return this.repository.login(email, password);
   }
 
-  async register(email: string, password: string): Promise<DbResult<Auth>> {
-    return this.repository.register(email, password);
+  async register(input: RegisterInput): Promise<DbResult<Auth>> {
+    const { data: auth, error } = await this.repository.register(
+      input.email,
+      input.password,
+    );
+    if (error) return { data: null, error };
+    if (!auth) return { data: null, error: null };
+
+    // Provisiona a clínica para o novo dono.
+    let clinicId: string | undefined;
+    try {
+      const clinic = await this.clinicService.createClinic({
+        name: input.clinicName,
+        cnpj: input.cnpj,
+        address: input.address,
+        phone: input.phone,
+        email: input.email,
+      });
+      clinicId = clinic.id;
+    } catch (err) {
+      console.error("[AuthService] failed to create clinic on register:", err);
+      throw new Error(
+        "Conta criada, mas não foi possível cadastrar a clínica.",
+        { cause: err },
+      );
+    }
+
+    // Cria o funcionário responsável (dono) vinculado à clínica.
+    try {
+      await this.employeeService.createEmployee({
+        name: input.ownerName,
+        cpf: input.cpf,
+        address: input.address,
+        phone: input.phone,
+        email: input.email,
+        role: "dono",
+        clinicId,
+      });
+    } catch (err) {
+      console.error("[AuthService] failed to create owner on register:", err);
+      // Rollback da clínica para não deixar registro órfão.
+      if (clinicId) {
+        await this.clinicService
+          .deleteClinic(clinicId)
+          .catch((e) =>
+            console.error("[AuthService] clinic rollback failed:", e),
+          );
+      }
+      throw new Error("Não foi possível cadastrar o usuário responsável.", {
+        cause: err,
+      });
+    }
+
+    return {
+      data: new Auth(auth.userId, auth.token, auth.refreshToken, clinicId),
+      error: null,
+    };
   }
 
   async refresh(refreshToken: string): Promise<DbResult<Auth>> {

--- a/src/pet_flow_backend/services/auth/domain/models/auth.ts
+++ b/src/pet_flow_backend/services/auth/domain/models/auth.ts
@@ -3,5 +3,6 @@ export class Auth {
     public readonly userId: string,
     public readonly token: string,
     public readonly refreshToken: string,
+    public readonly clinicId?: string,
   ) {}
 }

--- a/src/pet_flow_backend/services/auth/dto/mappers/auth-dto.mapper.ts
+++ b/src/pet_flow_backend/services/auth/dto/mappers/auth-dto.mapper.ts
@@ -8,6 +8,7 @@ export class AuthDtoMapper implements Mapper<Auth, AuthResponseDto> {
       user_id: fromObject.userId,
       token: fromObject.token,
       refresh_token: fromObject.refreshToken,
+      ...(fromObject.clinicId ? { clinic_id: fromObject.clinicId } : {}),
     };
   }
 

--- a/src/pet_flow_backend/services/auth/dto/models/auth-response.dto.ts
+++ b/src/pet_flow_backend/services/auth/dto/models/auth-response.dto.ts
@@ -2,4 +2,5 @@ export interface AuthResponseDto {
   user_id: string;
   token: string;
   refresh_token: string;
+  clinic_id?: string;
 }

--- a/src/pet_flow_backend/services/auth/index.ts
+++ b/src/pet_flow_backend/services/auth/index.ts
@@ -4,9 +4,34 @@ import { AuthService } from "./auth.service";
 import { AuthController } from "./auth.controller";
 import { AuthRoutes } from "./auth.routes";
 
+import { ClinicDatasourceImpl } from "../clinic/datasources/clinic.datasource.impl";
+import { ClinicRepositoryImpl } from "../clinic/repositories/clinic.repository.impl";
+import { ClinicMapper } from "../clinic/domain/mappers/clinic.mapper";
+import { ClinicService } from "../clinic/clinic.service";
+
+import { EmployeeDatasourceImpl } from "../employee/datasources/employee.datasource.impl";
+import { EmployeeRepositoryImpl } from "../employee/repositories/employee.repository.impl";
+import { EmployeeMapper } from "../employee/domain/mappers/employee.mapper";
+import { EmployeeService } from "../employee/employee.service";
+
 const authDatasource = new AuthDatasourceImpl();
 const authRepository = new AuthRepositoryImpl(authDatasource);
-const authService = new AuthService(authRepository);
+
+const clinicService = new ClinicService(
+  new ClinicRepositoryImpl(new ClinicDatasourceImpl(), new ClinicMapper()),
+);
+const employeeService = new EmployeeService(
+  new EmployeeRepositoryImpl(
+    new EmployeeDatasourceImpl(),
+    new EmployeeMapper(),
+  ),
+);
+
+const authService = new AuthService(
+  authRepository,
+  clinicService,
+  employeeService,
+);
 const authController = new AuthController(authService);
 const authRoutes = new AuthRoutes(authController).router;
 

--- a/src/pet_flow_mobile/src/navigation/AppNavigator.tsx
+++ b/src/pet_flow_mobile/src/navigation/AppNavigator.tsx
@@ -3,9 +3,11 @@ import { ActivityIndicator, View, Text, StyleSheet, TouchableOpacity } from 'rea
 import { NavigationContainer, getFocusedRouteNameFromRoute } from '@react-navigation/native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { MaterialIcons } from '@expo/vector-icons';
 import { useSession } from '../contexts/SessionContext';
 import { colors, fontSize, fontWeight } from '../theme';
 import LoginScreen from '../screens/login';
+import RegisterScreen from '../screens/register';
 import DashboardScreen from '../screens/dashboard';
 import FinancialScreen from '../screens/financial';
 import SchedulingScreen from '../screens/scheduling';
@@ -13,17 +15,13 @@ import DrawerContent from './DrawerContent';
 import { AuthRoutes, AppRoutes } from './routes';
 import EmployeesScreen from '../screens/employees';
 import ServiceScreen from '../screens/service';
+import ProductScreen from '../screens/product';
+import PetsScreen from '../screens/pets/pets';
+import VaccinesScreen from '../screens/pets/vaccines';
+import TutorsScreen from '../screens/tutor/tutor';
 
 const Drawer = createDrawerNavigator();
 const Stack = createNativeStackNavigator();
-
-function RegisterPlaceholder() {
-  return (
-    <View style={placeholderStyles.container}>
-      <Text style={placeholderStyles.text}>Tela de registro em construção...</Text>
-    </View>
-  );
-}
 
 function PagePlaceholder({ route }: { route: { params?: { title?: string } } }) {
   const title = route.params?.title || 'Em construção';
@@ -45,7 +43,7 @@ function AuthStack() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name={AuthRoutes.LOGIN} component={LoginScreen} />
-      <Stack.Screen name={AuthRoutes.REGISTER} component={RegisterPlaceholder} />
+      <Stack.Screen name={AuthRoutes.REGISTER} component={RegisterScreen} />
     </Stack.Navigator>
   );
 }
@@ -165,8 +163,7 @@ function AuthenticatedDrawer() {
 
       <Drawer.Screen
         name={AppRoutes.PRODUCTS}
-        component={PagePlaceholder}
-        initialParams={{ title: 'Produtos' }}
+        component={ProductScreen}
         options={{ title: 'Produtos' }}
       />
 

--- a/src/pet_flow_mobile/src/navigation/routes.ts
+++ b/src/pet_flow_mobile/src/navigation/routes.ts
@@ -7,6 +7,7 @@ export const AppRoutes = {
   DASHBOARD: 'Dashboard',
   SCHEDULING: 'Scheduling',
   PETS: 'Pets',
+  VACCINES: 'Vaccines',
   TUTORS: 'Tutors',
   SERVICES: 'Services',
   PRODUCTS: 'Products',

--- a/src/pet_flow_mobile/src/screens/product/api.ts
+++ b/src/pet_flow_mobile/src/screens/product/api.ts
@@ -1,0 +1,38 @@
+import { authRequest } from '../../services/http';
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  stock: number;
+  category: string;
+}
+
+export const productService = {
+  getAll(): Promise<Product[]> {
+    return authRequest<Product[]>('/product', {
+      method: 'GET',
+    });
+  },
+
+  create(payload: Partial<Product>): Promise<Product> {
+    return authRequest<Product>('/product', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  update(id: string, payload: Partial<Product>): Promise<Product> {
+    return authRequest<Product>(`/product/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  delete(id: string): Promise<void> {
+    return authRequest<void>(`/product/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};

--- a/src/pet_flow_mobile/src/screens/product/components/DeleteConfirmModal.tsx
+++ b/src/pet_flow_mobile/src/screens/product/components/DeleteConfirmModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { colors } from '../../../theme';
+import { modalStyles } from '../../scheduling/styles';
+
+interface Props {
+  visible: boolean;
+  title?: string;
+  message?: string;
+  loading?: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+export default function DeleteConfirmModal({ visible, title = 'Excluir', message = 'Deseja realmente excluir?', loading = false, onClose, onConfirm }: Props) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={modalStyles.overlay}>
+        <View style={[modalStyles.sheet, { paddingHorizontal: 24 }]}>
+          <View style={modalStyles.header}>
+            <Text style={modalStyles.title}>{title}</Text>
+          </View>
+
+          <View style={modalStyles.content}>
+            <Text style={{ color: colors.textPrimary, marginBottom: 16 }}>{message}</Text>
+
+            <View style={modalStyles.actions}>
+              <TouchableOpacity style={modalStyles.cancelButton} onPress={onClose} disabled={loading}>
+                <Text style={modalStyles.cancelButtonText}>Cancelar</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={[modalStyles.saveButton, loading && modalStyles.saveButtonDisabled]} onPress={onConfirm} disabled={loading}>
+                {loading ? <ActivityIndicator color={colors.textWhite} /> : <Text style={modalStyles.saveButtonText}>Excluir</Text>}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/pet_flow_mobile/src/screens/product/components/ProductModal.tsx
+++ b/src/pet_flow_mobile/src/screens/product/components/ProductModal.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, TextInput, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '../../../theme';
+import { modalStyles } from '../../scheduling/styles';
+import type { Product } from '../api';
+
+export interface ProductFormPayload {
+  name: string;
+  category: string;
+  description: string;
+  price: string;
+  stock: string;
+}
+
+interface Props {
+  visible: boolean;
+  product: Product | null;
+  onClose: () => void;
+  onSave: (payload: ProductFormPayload) => Promise<void> | void;
+  saving?: boolean;
+}
+
+export default function ProductModal({ visible, product, onClose, onSave, saving }: Props) {
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+  const [stock, setStock] = useState('');
+  const [error, setError] = useState('');
+  const [localSaving, setLocalSaving] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setName(product?.name || '');
+      setCategory(product?.category || '');
+      setDescription(product?.description || '');
+      setPrice(product ? String(product.price.toFixed(2)).replace('.', ',') : '');
+      setStock(product ? String(product.stock) : '');
+      setError('');
+    }
+  }, [visible, product]);
+
+  const isValid =
+    name.trim().length > 0 &&
+    category.trim().length > 0 &&
+    price.trim().length > 0 &&
+    stock.trim().length > 0;
+
+  const handleSubmit = async () => {
+    setError('');
+
+    if (name.trim().length < 3) {
+      setError('Nome deve ter no mínimo 3 caracteres');
+      return;
+    }
+
+    if (category.trim().length === 0) {
+      setError('Categoria é obrigatória');
+      return;
+    }
+
+    const parsedPrice = parseFloat(price.replace(/\./g, '').replace(',', '.')) || 0;
+    if (parsedPrice <= 0) {
+      setError('Preço deve ser maior que 0');
+      return;
+    }
+
+    const parsedStock = parseInt(stock, 10);
+    if (isNaN(parsedStock) || parsedStock < 0) {
+      setError('Estoque deve ser maior ou igual a 0');
+      return;
+    }
+
+    setLocalSaving(true);
+    try {
+      await onSave({
+        name: name.trim(),
+        category: category.trim(),
+        description: description.trim(),
+        price: price.trim(),
+        stock: stock.trim(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao salvar produto');
+    } finally {
+      setLocalSaving(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={modalStyles.overlay}>
+        <View style={modalStyles.sheet}>
+          <View style={modalStyles.handle} />
+
+          <View style={modalStyles.header}>
+            <Text style={modalStyles.title}>{product ? 'Editar Produto' : 'Novo Produto'}</Text>
+            <TouchableOpacity style={modalStyles.closeButton} onPress={onClose} disabled={saving}>
+              <MaterialIcons name="close" size={20} color={colors.textPrimary} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={modalStyles.content}>
+            {error ? <Text style={[modalStyles.helperText, { color: '#DC2626' }]}>{error}</Text> : null}
+            <Text style={modalStyles.label}>Nome</Text>
+            <TextInput style={modalStyles.input} value={name} onChangeText={setName} placeholder="Ex: Ração Premium" placeholderTextColor={colors.textPlaceholder} />
+
+            <Text style={modalStyles.label}>Categoria</Text>
+            <TextInput style={modalStyles.input} value={category} onChangeText={setCategory} placeholder="Ex: Alimentação, Higiene, Acessórios" placeholderTextColor={colors.textPlaceholder} />
+
+            <Text style={modalStyles.label}>Descrição</Text>
+            <TextInput style={[modalStyles.input, modalStyles.textArea]} value={description} onChangeText={setDescription} placeholder="Descrição do produto" placeholderTextColor={colors.textPlaceholder} multiline textAlignVertical="top" />
+
+            <Text style={modalStyles.label}>Preço (R$)</Text>
+            <TextInput style={modalStyles.input} value={price} onChangeText={setPrice} placeholder="0,00" placeholderTextColor={colors.textPlaceholder} keyboardType="numeric" />
+
+            <Text style={modalStyles.label}>Estoque</Text>
+            <TextInput style={modalStyles.input} value={stock} onChangeText={setStock} placeholder="Ex: 10" placeholderTextColor={colors.textPlaceholder} keyboardType="numeric" />
+
+            <View style={modalStyles.actions}>
+              <TouchableOpacity style={modalStyles.cancelButton} onPress={onClose} disabled={saving}>
+                <Text style={modalStyles.cancelButtonText}>Cancelar</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={[modalStyles.saveButton, (!isValid || localSaving || saving) && modalStyles.saveButtonDisabled]} onPress={handleSubmit} disabled={!isValid || localSaving || saving}>
+                {localSaving || saving ? <ActivityIndicator color={colors.textWhite} /> : <Text style={modalStyles.saveButtonText}>{product ? 'Atualizar' : 'Salvar'}</Text>}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/pet_flow_mobile/src/screens/product/index.tsx
+++ b/src/pet_flow_mobile/src/screens/product/index.tsx
@@ -1,0 +1,250 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { styles } from './styles';
+import ProductModal, { type ProductFormPayload } from './components/ProductModal';
+import DeleteConfirmModal from './components/DeleteConfirmModal';
+import { productService, type Product } from './api';
+
+const LOW_STOCK_THRESHOLD = 5;
+
+function parsePrice(value: string): number {
+  return parseFloat(value.replace(/\./g, '').replace(',', '.')) || 0;
+}
+
+export default function ProductScreen() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingProductId, setEditingProductId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+  const [productToDeleteId, setProductToDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  async function loadProducts() {
+    try {
+      const data = await productService.getAll();
+      setProducts(data);
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Erro', 'Não foi possível carregar os produtos.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleDelete(id: string) {
+    setProductToDeleteId(id);
+    setDeleteModalVisible(true);
+  }
+
+  async function confirmDelete() {
+    if (!productToDeleteId) return;
+
+    setDeleting(true);
+
+    try {
+      await productService.delete(productToDeleteId);
+
+      setProducts((prev) => prev.filter((p) => p.id !== productToDeleteId));
+
+      setDeleteModalVisible(false);
+      setProductToDeleteId(null);
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Erro', 'Não foi possível excluir.');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  function handleEdit(product: Product) {
+    setEditingProductId(product.id);
+    setShowForm(true);
+  }
+
+  async function handleSaveFromModal(payload: ProductFormPayload) {
+    setSaving(true);
+
+    const data = {
+      name: payload.name,
+      category: payload.category,
+      description: payload.description,
+      price: parsePrice(payload.price),
+      stock: parseInt(payload.stock, 10),
+    };
+
+    try {
+      if (editingProductId) {
+        const updated = await productService.update(editingProductId, data);
+        setProducts((prev) => prev.map((p) => (p.id === editingProductId ? updated : p)));
+
+        setEditingProductId(null);
+        setShowForm(false);
+
+        Alert.alert('Sucesso', 'Produto atualizado.');
+      } else {
+        const created = await productService.create(data);
+        setProducts((prev) => [created, ...prev]);
+
+        setShowForm(false);
+
+        Alert.alert('Sucesso', 'Produto criado com sucesso.');
+      }
+    } catch (error) {
+      console.error(error);
+      // Propagate error to modal so it can show messages
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const editingProduct = products.find((p) => p.id === editingProductId) ?? null;
+
+  const filteredProducts = useMemo(() => {
+    return products.filter((product) =>
+      product.name.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [products, search]);
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.searchContainer}>
+        <TextInput
+          placeholder="Buscar por produto..."
+          value={search}
+          onChangeText={setSearch}
+          style={styles.searchInput}
+        />
+      </View>
+
+      <TouchableOpacity
+        style={styles.addButton}
+        onPress={() => {
+          setEditingProductId(null);
+          setShowForm(true);
+        }}
+      >
+        <MaterialIcons name="add" size={24} color="#FFF" />
+        <Text style={styles.addButtonText}>Novo Produto</Text>
+      </TouchableOpacity>
+
+      <ProductModal
+        visible={showForm}
+        product={editingProduct}
+        onClose={() => {
+          setShowForm(false);
+          setEditingProductId(null);
+        }}
+        onSave={handleSaveFromModal}
+        saving={saving}
+      />
+
+      <DeleteConfirmModal
+        visible={deleteModalVisible}
+        title="Excluir produto"
+        message="Deseja realmente excluir este produto?"
+        loading={deleting}
+        onClose={() => {
+          setDeleteModalVisible(false);
+          setProductToDeleteId(null);
+        }}
+        onConfirm={confirmDelete}
+      />
+
+      <FlatList
+        data={filteredProducts}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        scrollEnabled={true}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>Nenhum produto encontrado.</Text>
+        }
+        renderItem={({ item }) => {
+          const isLowStock = item.stock <= LOW_STOCK_THRESHOLD;
+
+          return (
+            <View style={styles.card}>
+              <View style={styles.cardContent}>
+                <View style={styles.cardHeader}>
+                  <Text style={styles.productName}>{item.name}</Text>
+                  {item.category ? (
+                    <View style={styles.categoryTag}>
+                      <Text style={styles.categoryTagText}>{item.category}</Text>
+                    </View>
+                  ) : null}
+                </View>
+
+                {item.description ? (
+                  <Text style={styles.productDescription}>{item.description}</Text>
+                ) : null}
+
+                <View style={styles.productMetadata}>
+                  <View style={styles.priceAndStock}>
+                    <View style={styles.priceContainer}>
+                      <Text style={styles.price}>R$ {item.price.toFixed(2)}</Text>
+                    </View>
+
+                    <View style={styles.stockContainer}>
+                      <MaterialIcons
+                        name="inventory-2"
+                        size={16}
+                        color={isLowStock ? '#DE6767' : '#6B7280'}
+                      />
+                      <Text style={[styles.stock, isLowStock && styles.stockLow]}>
+                        {item.stock} un.
+                      </Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.actions}>
+                    <TouchableOpacity
+                      style={styles.editBtn}
+                      onPress={() => handleEdit(item)}
+                    >
+                      <MaterialIcons name="edit" size={18} color="#2563EB" />
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                      style={styles.deleteBtn}
+                      onPress={() => handleDelete(item.id)}
+                    >
+                      <MaterialIcons name="delete" size={18} color="#DC2626" />
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              </View>
+            </View>
+          );
+        }}
+      />
+    </View>
+  );
+}

--- a/src/pet_flow_mobile/src/screens/product/styles.ts
+++ b/src/pet_flow_mobile/src/screens/product/styles.ts
@@ -1,0 +1,177 @@
+import { StyleSheet } from 'react-native';
+import { colors, spacing, fontSize, radius, fontWeight } from '../../theme';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgMain,
+  },
+
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.bgMain,
+  },
+
+  searchContainer: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    marginBottom: spacing.md,
+  },
+
+  searchInput: {
+    backgroundColor: colors.bgWhite,
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    fontSize: fontSize.base,
+    color: colors.textPrimary,
+  },
+
+  addButton: {
+    backgroundColor: colors.primary,
+    marginHorizontal: spacing.lg,
+    marginBottom: spacing.md,
+    paddingVertical: 12,
+    borderRadius: radius.lg,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+
+  addButtonText: {
+    color: colors.textWhite,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+  },
+
+  list: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xxxl,
+  },
+
+  card: {
+    backgroundColor: colors.bgWhite,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    marginBottom: spacing.md,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+  },
+
+  cardContent: {
+    flex: 1,
+  },
+
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+
+  productName: {
+    fontSize: fontSize.md,
+    fontWeight: fontWeight.semibold,
+    color: colors.textPrimary,
+    flexShrink: 1,
+  },
+
+  categoryTag: {
+    backgroundColor: colors.primaryBg,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+    marginLeft: spacing.sm,
+  },
+
+  categoryTagText: {
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.medium,
+    color: colors.primary,
+  },
+
+  productDescription: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+    marginBottom: spacing.sm,
+  },
+
+  productMetadata: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+
+  priceAndStock: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+
+  priceContainer: {
+    backgroundColor: '#E8F1FF',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.sm,
+  },
+
+  price: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.semibold,
+    color: colors.primary,
+  },
+
+  stockContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+
+  stock: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+  },
+
+  stockLow: {
+    color: colors.danger,
+    fontWeight: fontWeight.semibold,
+  },
+
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+
+  editBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.md,
+    backgroundColor: colors.primaryBg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  deleteBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.md,
+    backgroundColor: colors.dangerBg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  emptyText: {
+    textAlign: 'center',
+    color: colors.textPlaceholder,
+    fontSize: fontSize.base,
+    paddingVertical: spacing.xxxl,
+  },
+});

--- a/src/pet_flow_mobile/src/screens/register/index.tsx
+++ b/src/pet_flow_mobile/src/screens/register/index.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { colors } from '../../theme';
+import { useRegister } from './useRegister';
+import { styles } from '../login/styles';
+
+export default function RegisterScreen() {
+  const {
+    clinicName,
+    setClinicName,
+    cnpj,
+    setCnpj,
+    phone,
+    setPhone,
+    address,
+    setAddress,
+    ownerName,
+    setOwnerName,
+    cpf,
+    setCpf,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    showPassword,
+    togglePassword,
+    error,
+    loading,
+    isFormValid,
+    handleRegister,
+    goToLogin,
+  } = useRegister();
+
+  return (
+    <View style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.keyboardView}
+      >
+        <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+          <View style={styles.logoContainer}>
+            <MaterialIcons name="pets" size={48} color={colors.primary} />
+            <Text style={styles.logoText}>
+              pet<Text style={styles.logoTextFlow}>flow</Text>
+            </Text>
+          </View>
+
+          <View style={styles.formContainer}>
+            <Text style={styles.title}>Crie sua conta</Text>
+            <Text style={styles.subtitle}>Cadastre sua clínica e o responsável.</Text>
+
+            <Text style={styles.label}>Nome da clínica:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Clínica Pet Feliz"
+              placeholderTextColor={colors.textPlaceholder}
+              value={clinicName}
+              onChangeText={setClinicName}
+            />
+
+            <Text style={styles.label}>CNPJ:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="00.000.000/0000-00"
+              placeholderTextColor={colors.textPlaceholder}
+              value={cnpj}
+              onChangeText={setCnpj}
+              keyboardType="numbers-and-punctuation"
+            />
+
+            <Text style={styles.label}>Telefone:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="(00) 00000-0000"
+              placeholderTextColor={colors.textPlaceholder}
+              value={phone}
+              onChangeText={setPhone}
+              keyboardType="phone-pad"
+            />
+
+            <Text style={styles.label}>Endereço:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Rua, número, bairro"
+              placeholderTextColor={colors.textPlaceholder}
+              value={address}
+              onChangeText={setAddress}
+            />
+
+            <Text style={styles.label}>Nome do responsável:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Seu nome completo"
+              placeholderTextColor={colors.textPlaceholder}
+              value={ownerName}
+              onChangeText={setOwnerName}
+            />
+
+            <Text style={styles.label}>CPF:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="000.000.000-00"
+              placeholderTextColor={colors.textPlaceholder}
+              value={cpf}
+              onChangeText={setCpf}
+              keyboardType="numbers-and-punctuation"
+            />
+
+            <Text style={styles.label}>E-mail:</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="nome@petflow.com.br"
+              placeholderTextColor={colors.textPlaceholder}
+              value={email}
+              onChangeText={setEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+
+            <Text style={styles.label}>Senha:</Text>
+            <View style={styles.passwordWrapper}>
+              <TextInput
+                style={styles.passwordInput}
+                placeholder="Mínimo de 6 caracteres"
+                placeholderTextColor={colors.textPlaceholder}
+                value={password}
+                onChangeText={setPassword}
+                secureTextEntry={!showPassword}
+              />
+              <TouchableOpacity style={styles.eyeBtn} onPress={togglePassword}>
+                <MaterialIcons
+                  name={showPassword ? 'visibility-off' : 'visibility'}
+                  size={20}
+                  color={colors.textPlaceholder}
+                />
+              </TouchableOpacity>
+            </View>
+
+            {error ? <Text style={styles.error}>{error}</Text> : null}
+
+            <TouchableOpacity
+              style={[styles.button, !isFormValid && styles.buttonDisabled]}
+              onPress={handleRegister}
+              disabled={loading || !isFormValid}
+            >
+              {loading ? (
+                <ActivityIndicator color={colors.textWhite} />
+              ) : (
+                <Text style={styles.buttonText}>Cadastrar</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.registerLink} onPress={goToLogin}>
+              <Text style={styles.registerText}>
+                Já tem uma conta? <Text style={styles.registerBold}>Entrar</Text>
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}

--- a/src/pet_flow_mobile/src/screens/register/useRegister.ts
+++ b/src/pet_flow_mobile/src/screens/register/useRegister.ts
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { authService, authStorage, authRequest } from '../../services';
+import type { Employee } from '../../types';
+import { useSession } from '../../contexts/SessionContext';
+import { AuthRoutes } from '../../navigation/routes';
+
+export function useRegister() {
+  const navigation = useNavigation<any>();
+  const { setSession } = useSession();
+
+  const [clinicName, setClinicName] = useState('');
+  const [cnpj, setCnpj] = useState('');
+  const [phone, setPhone] = useState('');
+  const [address, setAddress] = useState('');
+  const [ownerName, setOwnerName] = useState('');
+  const [cpf, setCpf] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const togglePassword = () => setShowPassword(!showPassword);
+
+  const isFormValid =
+    clinicName.trim().length > 0 &&
+    ownerName.trim().length > 0 &&
+    email.length > 0 &&
+    password.length > 0;
+
+  const goToLogin = () => navigation.navigate(AuthRoutes.LOGIN);
+
+  const handleRegister = async () => {
+    setError('');
+
+    if (!clinicName.trim() || !ownerName.trim() || !email || !password) {
+      setError('Preencha os campos obrigatórios.');
+      return;
+    }
+
+    if (!email.endsWith('@petflow.com.br')) {
+      setError('O e-mail deve ter o formato @petflow.com.br');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('A senha deve ter no mínimo 6 caracteres.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      let data = await authService.register({
+        clinicName: clinicName.trim(),
+        cnpj: cnpj.trim(),
+        phone: phone.trim(),
+        address: address.trim(),
+        ownerName: ownerName.trim(),
+        cpf: cpf.trim(),
+        email,
+        password,
+      });
+
+      // Caso o cadastro não retorne sessão (ex.: confirmação de e-mail),
+      // autentica em seguida para obter um token válido.
+      if (!data.token) {
+        data = await authService.login(email, password);
+      }
+
+      await authStorage.save(data);
+
+      let clinicId = data.clinic_id || '';
+      let name = ownerName.trim();
+      let role = 'dono';
+
+      try {
+        const me = await authRequest<Employee>('/employee/me', { method: 'GET' });
+        clinicId = me.clinicId || clinicId;
+        name = me.name || name;
+        role = me.role || role;
+      } catch {
+        // mantém os valores já definidos a partir do cadastro
+      }
+
+      const sessionData = { token: data.token, userId: data.user_id, clinicId, name, role };
+
+      await authStorage.saveSessionData(sessionData);
+      setSession(sessionData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao cadastrar.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    clinicName,
+    setClinicName,
+    cnpj,
+    setCnpj,
+    phone,
+    setPhone,
+    address,
+    setAddress,
+    ownerName,
+    setOwnerName,
+    cpf,
+    setCpf,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    showPassword,
+    togglePassword,
+    error,
+    loading,
+    isFormValid,
+    handleRegister,
+    goToLogin,
+  };
+}


### PR DESCRIPTION
Backend (POST /auth/register):
- Provisiona Auth user, clínica e funcionário responsável (role dono) em uma única operação, com rollback da clínica em caso de falha.
- Valida campos obrigatórios e retorna clinic_id na resposta.

App mobile:
- Adiciona tela de cadastro (clínica + responsável) ligada ao authService.register, com autenticação automática pós-cadastro.
- Substitui o placeholder de registro pela tela real.

Inclui também mudanças que já estavam pendentes no working tree: ativação da tela de Produtos, rota Vaccines e ajuste no .gitignore.